### PR TITLE
implement send BelFox for CUL 433

### DIFF
--- a/culfw/Devices/CUL/CUL.c
+++ b/culfw/Devices/CUL/CUL.c
@@ -56,6 +56,9 @@
 #ifdef HAS_KOPP_FC
 #include "kopp-fc.h"
 #endif
+#ifdef HAS_BELFOX
+#include "belfox.h"
+#endif
 
 const PROGMEM t_fntab fntab[] = {
 
@@ -103,6 +106,9 @@ const PROGMEM t_fntab fntab[] = {
 #endif
 #ifdef HAS_MEMFN
   { 'm', getfreemem },
+#endif
+#ifdef HAS_BELFOX
+  { 'L', send_belfox },
 #endif
   { 'l', ledfunc },
   { 't', gettime },

--- a/culfw/Devices/CUL/board.h
+++ b/culfw/Devices/CUL/board.h
@@ -43,6 +43,7 @@
 #    define HAS_IT
 #    define HAS_HOMEEASY
 #    define HAS_OREGON3
+#    define HAS_BELFOX
 #  endif
 
 #if defined(_868MHZ)

--- a/culfw/Devices/CUL/makefile
+++ b/culfw/Devices/CUL/makefile
@@ -8,6 +8,7 @@ SRC =           CUL.c\
 		../../clib/cc1101_pllcheck.c                         \
 		../../clib/cdcLUFA.c                                 \
 		../../clib/clock.c                                   \
+		../../clib/belfox.c                                  \
 		../../clib/delay.c                                   \
 		../../clib/display.c                                 \
 		../../clib/stringfunc.c                              \

--- a/culfw/clib/belfox.c
+++ b/culfw/clib/belfox.c
@@ -1,0 +1,116 @@
+/* 
+   Copyright by GWu
+   License: LGPL v2.1
+   --
+   provides send function for BelFox door sender
+   see http://forum.fhem.de/index.php/topic,36810.0.html for discussion and documentation
+   --
+*/
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdio.h>
+#include <util/parity.h>
+#include <string.h>
+
+#include "board.h"
+
+#ifdef HAS_BELFOX
+
+#include "delay.h"
+#include "belfox.h"
+#include "rf_receive.h"
+#include "led.h"
+#include "cc1100.h"
+
+#ifdef HAS_MORITZ
+#include "rf_moritz.h"
+#endif
+
+// define timings
+#define BELFOX_ZERO_HIGH               1000  // 1000uS
+#define BELFOX_ZERO_LOW  2*BELFOX_ZERO_HIGH  
+#define BELFOX_ONE_HIGH  2*BELFOX_ZERO_HIGH
+#define BELFOX_ONE_LOW     BELFOX_ZERO_HIGH
+#define BELFOX_PAUSE                     35  // 35ms
+#define BELFOX_REPEAT                     4  // repeat 4 times
+#define BELFOX_LEN                       12  // length of message
+
+// send sync flag
+static void
+send_sync(void)
+{
+  CC1100_OUT_PORT |= _BV(CC1100_OUT_PIN);         // High
+  my_delay_us(BELFOX_ZERO_HIGH);
+}
+ 
+// send belfox bit (low/high)
+static void
+send_bit(uint8_t bit)
+{
+  CC1100_OUT_PORT &= ~_BV(CC1100_OUT_PIN);        // Low
+  my_delay_us(bit ? BELFOX_ONE_LOW  : BELFOX_ZERO_LOW );
+
+  CC1100_OUT_PORT |= _BV(CC1100_OUT_PIN);         // High
+  my_delay_us(bit ? BELFOX_ONE_HIGH : BELFOX_ZERO_HIGH );
+}
+
+void
+send_belfox(char *msg)
+{
+
+  uint8_t repeat=BELFOX_REPEAT;
+  uint8_t len=strnlen(msg,BELFOX_LEN+2)-1;
+  
+  // assert if length incorrect
+  if (len != BELFOX_LEN) return;
+  
+  LED_ON();
+
+#if defined (HAS_IRRX) || defined (HAS_IRTX) // Block IR_Reception
+  cli();
+#endif
+
+#ifdef HAS_MORITZ
+  uint8_t restore_moritz = 0;
+  if(moritz_on) {
+    restore_moritz = 1;
+    moritz_on = 0;
+    set_txreport("21");
+  }
+#endif
+
+  if(!cc_on)
+    set_ccon();
+  ccTX();                                       // Enable TX 
+  do {
+    send_sync();                                // sync
+
+    for(int i = 1; i <= BELFOX_LEN; i++)        // loop input, for example 'L111001100110'
+      send_bit(msg[i] == '1');
+
+    CC1100_OUT_PORT &= ~_BV(CC1100_OUT_PIN);    // final low to complete last bit
+        
+    my_delay_ms(BELFOX_PAUSE);                  // pause
+
+  } while(--repeat > 0);
+
+  if(tx_report) {                               // Enable RX
+    ccRX();
+  } else {
+    ccStrobe(CC1100_SIDLE);
+  }
+
+#if defined (HAS_IRRX) || defined (HAS_IRTX) // Activate IR_Reception
+  sei(); 
+#endif
+
+#ifdef HAS_MORITZ
+  if(restore_moritz)
+    rf_moritz_init();
+#endif
+
+  LED_OFF();
+}
+
+#endif

--- a/culfw/clib/belfox.h
+++ b/culfw/clib/belfox.h
@@ -1,0 +1,7 @@
+#ifndef _BelFox_H
+#define _BelFox_H
+
+/* public prototypes */
+void send_belfox(char *msg);
+
+#endif

--- a/culfw/docs/commandref.html
+++ b/culfw/docs/commandref.html
@@ -50,6 +50,7 @@
     <a href="#cmd_I">I</a>
     <a href="#cmd_i">i</a>
     <a href="#cmd_M">M</a>
+    <a href="#cmd_L">L</a>
     <a href="#cmd_l">l</a>
     <a href="#cmd_O">O</a>
     <a href="#cmd_o">o</a>
@@ -567,6 +568,22 @@
       <li>3333: top value  (Not set for type 2)
       </ul>
       Example: M02054A140000000000
+    </ul><br><br>
+
+    <a name="cmd_L"></a>
+    L&lt;code&gt;
+    <ul>
+      Send BelFox door opener code: xxxxxxxxxxyy
+      <ul>
+        <li>xxxxxxxxxx ... 10bit DIP code (resembles the positions of the DIP switches inside the sender)</li>
+        <li>        yy ...  2bit button code</li>
+        <ul>
+          <li>11 .. top button</li>
+          <li>01 .. bottom button</li>
+        </ul>
+      </ul>
+      Example: L101001100111 - DIP switches in position 1010011001, top button </br>
+      see also <a href="http://forum.fhem.de/index.php?topic=36810.msg291267">forum thread</a> (in german)
     </ul><br><br>
 
     <a name="cmd_l"></a>


### PR DESCRIPTION
Hallo Björn,

auf Anfrage von chris1284 im fhem Forum (http://forum.fhem.de/index.php/topic,35064.msg291387.html#msg291387) habe ich das BelFox Protokoll in die a-culfw für den CUL 433 V3 integriert.

Getestet habe ich mit IT senden+empfangen, SOMFY senden und BelFox senden, soweit alles ok.

Wenn Du magst, kannst Du das ja bei Dir übernehmen.

Beste Grüße,
 Georg
