### PR TITLE
Store it repetition in eeprom

### DIFF
--- a/culfw/clib/fncollection.h
+++ b/culfw/clib/fncollection.h
@@ -91,6 +91,7 @@ void do_wdt_enable(uint8_t t);
 # define EE_FS_LAST           (EE_LOGENABLED+1)
 #endif
 
+# define EE_ITREPETITIONS     (EE_LCD_LAST+1)
 
 
 extern uint8_t led_mode;

--- a/culfw/clib/intertechno.c
+++ b/culfw/clib/intertechno.c
@@ -359,6 +359,8 @@ it_send (char *in, uint8_t datatype) {
 	{
 		//yep, first call -> read it_repetition from eeprom
 		it_repetition = erb(EE_ITREPETITIONS);
+		//check if it is 0xff (default eeprom value), then set default to 6
+		if(it_repetition == 0xff) it_repetition = 6;
 		it_repetition_set = 1;
 	}
 	


### PR DESCRIPTION
Hey.

Here is my pull request.
With this changes the ITrepetition value is stored in the eeprom.
This much better than switch isr when in FHEM the ITrepetition is set, sending the IT cmd and switching isr back.

Here is the german Thread: https://forum.fhem.de/index.php/topic,79285.0.html

pOpY