### PR TITLE
new cmd "isrdXXX" (where XXX is 1-253) which will be stored in eeprom as

### DIFF
--- a/culfw/clib/fncollection.h
+++ b/culfw/clib/fncollection.h
@@ -91,6 +91,7 @@ void do_wdt_enable(uint8_t t);
 # define EE_FS_LAST           (EE_LOGENABLED+1)
 #endif
 
+# define EE_ITREPETITIONS     (EE_LCD_LAST+1)
 
 
 extern uint8_t led_mode;

--- a/culfw/version.h
+++ b/culfw/version.h
@@ -1,6 +1,6 @@
 #define VERSION_1               1
 #define VERSION_2               26
 #define VERSION                 "1.26.01"
-#define BUILD_DATE              "unknown"
-#define BUILD_NUMBER            "private build"
+#define BUILD_DATE              "12.11.2017"
+#define BUILD_NUMBER            "ITrepetition Test2"
 #define FW_NAME                 "a-culfw"


### PR DESCRIPTION
Here is my pull request.
With new cmd "isrdXXX" (where XXX is 1-253) a default ITrepetition value can be stored in eeprom. This value will be used when no isr cmd is received before (for backward compatibility). 

Here is the german Thread: https://forum.fhem.de/index.php/topic,79285.0.html

pOpY