### PR TITLE
MapleCUN: allow STM32 uart 1 to be used as serial 3 (via CDC_COUNT = 4)

### DIFF
--- a/culfw/Devices/MapleCUN/board.h
+++ b/culfw/Devices/MapleCUN/board.h
@@ -59,11 +59,17 @@
 #define HAS_USB
 //#define USB_FIX_SERIAL          "012345"
 #define CDC_COUNT               3
+// #define CDC_COUNT                 4
 #define CDC_BAUD_RATE           115200
 #define USB_IsConnected		      (CDC_isConnected(0))
 #define HAS_XRAM
+#if CDC_COUNT < 4
 #define UART_BAUD_RATE          115200
 #define HAS_UART                1
+#else
+#undef UART_BAUD_RATE
+#undef HAS_UART
+#endif
 #define USE_RF_MODE
 #define USE_HAL
 #define HAS_ONEWIRE             10        // OneWire Support

--- a/culfw/Devices/MapleCUN/board.h
+++ b/culfw/Devices/MapleCUN/board.h
@@ -56,6 +56,8 @@
 
 #define ARM
 
+#define DCHP_HOST_NAME "MapleCUN\0"
+
 #define HAS_USB
 //#define USB_FIX_SERIAL          "012345"
 #define CDC_COUNT               3

--- a/culfw/STM32/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc/usbd_cdc.h
+++ b/culfw/STM32/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc/usbd_cdc.h
@@ -64,6 +64,10 @@
 #define CDC3_OUT_EP                                 0x05  /* EP5 for data OUT */
 #define CDC3_CMD_EP                                 0x86  /* EP6 for CDC commands */
 
+#define CDC4_IN_EP                                  0x87  /* EP5 for data IN */
+#define CDC4_OUT_EP                                 0x07  /* EP5 for data OUT */
+#define CDC4_CMD_EP                                 0x88  /* EP6 for CDC commands */
+
 /* CDC Endpoints parameters: you can fine tune these values depending on the needed baudrates and performance. */
 #define CDC_DATA_HS_MAX_PACKET_SIZE                 64  /* Endpoint IN & OUT Packet size */
 #define CDC_DATA_FS_MAX_PACKET_SIZE                 64  /* Endpoint IN & OUT Packet size */

--- a/culfw/STM32/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
+++ b/culfw/STM32/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
@@ -131,6 +131,9 @@ static uint8_t  *USBD_CDC_GetOtherSpeedCfgDesc (uint16_t *length);
 
 uint8_t  *USBD_CDC_GetDeviceQualifierDescriptor (uint16_t *length);
 
+uint8_t *USBD_CDC_GetUsrStrDescriptor(struct _USBD_HandleTypeDef *pdev ,uint8_t index,  uint16_t *length);   
+
+
 /* USB Standard Device Descriptor */
 __ALIGN_BEGIN static uint8_t USBD_CDC_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] __ALIGN_END =
 {
@@ -172,6 +175,7 @@ USBD_ClassTypeDef  USBD_CDC =
   USBD_CDC_GetFSCfgDesc,    
   USBD_CDC_GetOtherSpeedCfgDesc, 
   USBD_CDC_GetDeviceQualifierDescriptor,
+  USBD_CDC_GetUsrStrDescriptor
 };
 
 /* USB CDC device Configuration Descriptor */
@@ -180,8 +184,8 @@ __ALIGN_BEGIN uint8_t USBD_CDC_CfgHSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END =
   /*Configuration Descriptor*/
   0x09,   /* bLength: Configuration Descriptor size */
   USB_DESC_TYPE_CONFIGURATION,      /* bDescriptorType: Configuration */
-  USB_CDC_CONFIG_DESC_SIZ,                /* wTotalLength:no of returned bytes */
-  0x00,
+  USB_CDC_CONFIG_DESC_SIZ & 0xff,                /* wTotalLength:no of returned bytes */
+  (USB_CDC_CONFIG_DESC_SIZ >> 8) & 0xff,
   USB_NUM_INTERFACES,   /* bNumInterfaces: 4 interface */
   0x01,   /* bConfigurationValue: Configuration value */
   0x00,   /* iConfiguration: Index of string descriptor describing the configuration */
@@ -287,7 +291,7 @@ __ALIGN_BEGIN uint8_t USBD_CDC_CfgHSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END =
   0x02, // bFunctionClass: CDC
   0x02, // bFunctionSubClass
   0x01, // bFunctionProtocol
-  0x02, // iFunction
+  0x21, // iFunction
 
   /*Interface Descriptor */
   0x09,   /* bLength: Interface Descriptor size */
@@ -377,7 +381,7 @@ __ALIGN_BEGIN uint8_t USBD_CDC_CfgHSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END =
   0x02, // bFunctionClass: CDC
   0x02, // bFunctionSubClass
   0x01, // bFunctionProtocol
-  0x02, // iFunction
+  0x31, // iFunction
 
   /*Interface Descriptor */
   0x09,   /* bLength: Interface Descriptor size */
@@ -452,6 +456,96 @@ __ALIGN_BEGIN uint8_t USBD_CDC_CfgHSDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIGN_END =
   0x07,   /* bLength: Endpoint Descriptor size */
   USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
   CDC3_IN_EP,                         /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),
+  0x00,                               /* bInterval: ignore for Bulk transfer */
+#endif
+  /*---------------------------------------------------------------------------*/
+#if (CDC_COUNT > 3)
+  // IAD
+  0x08, // bLength: Interface Descriptor size
+  0x0B,   // bDescriptorType: IAD
+  0x06, // bFirstInterface
+  0x02, // bInterfaceCount
+  0x02, // bFunctionClass: CDC
+  0x02, // bFunctionSubClass
+  0x01, // bFunctionProtocol
+  0x11, // iFunction
+
+  /*Interface Descriptor */
+  0x09,   /* bLength: Interface Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: Interface */
+  /* Interface descriptor type */
+  0x06,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x01,   /* bNumEndpoints: One endpoints used */
+  0x02,   /* bInterfaceClass: Communication Interface Class */
+  0x02,   /* bInterfaceSubClass: Abstract Control Model */
+  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* iInterface: */
+
+  /*Header Functional Descriptor*/
+  0x05,   /* bLength: Endpoint Descriptor size */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x00,   /* bDescriptorSubtype: Header Func Desc */
+  0x10,   /* bcdCDC: spec release number */
+  0x01,
+
+  /*Call Management Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x01,   /* bDescriptorSubtype: Call Management Func Desc */
+  0x00,   /* bmCapabilities: D0+D1 */
+  0x07,   /* bDataInterface: 7 */
+
+  /*ACM Functional Descriptor*/
+  0x04,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x02,   /* bDescriptorSubtype: Abstract Control Management desc */
+  0x02,   /* bmCapabilities */
+
+  /*Union Functional Descriptor*/
+  0x05,   /* bFunctionLength */
+  0x24,   /* bDescriptorType: CS_INTERFACE */
+  0x06,   /* bDescriptorSubtype: Union func desc */
+  0x06,   /* bMasterInterface: Communication class interface */
+  0x07,   /* bSlaveInterface0: Data Class Interface */
+
+  /*Endpoint 2 Descriptor*/
+  0x07,                           /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,   /* bDescriptorType: Endpoint */
+  CDC4_CMD_EP,                     /* bEndpointAddress */
+  0x03,                           /* bmAttributes: Interrupt */
+  LOBYTE(CDC_CMD_PACKET_SIZE),     /* wMaxPacketSize: */
+  HIBYTE(CDC_CMD_PACKET_SIZE),
+  0xFF,                           /* bInterval: */
+  /*---------------------------------------------------------------------------*/
+
+  /*Data class interface descriptor*/
+  0x09,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_INTERFACE,  /* bDescriptorType: */
+  0x07,   /* bInterfaceNumber: Number of Interface */
+  0x00,   /* bAlternateSetting: Alternate setting */
+  0x02,   /* bNumEndpoints: Two endpoints used */
+  0x0A,   /* bInterfaceClass: CDC */
+  0x00,   /* bInterfaceSubClass: */
+  0x00,   /* bInterfaceProtocol: */
+  0x00,   /* iInterface: */
+
+  /*Endpoint OUT Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC4_OUT_EP,                        /* bEndpointAddress */
+  0x02,                              /* bmAttributes: Bulk */
+  LOBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
+  HIBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),
+  0x00,                              /* bInterval: ignore for Bulk transfer */
+
+  /*Endpoint IN Descriptor*/
+  0x07,   /* bLength: Endpoint Descriptor size */
+  USB_DESC_TYPE_ENDPOINT,      /* bDescriptorType: Endpoint */
+  CDC4_IN_EP,                         /* bEndpointAddress */
   0x02,                              /* bmAttributes: Bulk */
   LOBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),  /* wMaxPacketSize: */
   HIBYTE(CDC_DATA_HS_MAX_PACKET_SIZE),
@@ -807,6 +901,22 @@ uint8_t  *USBD_CDC_GetDeviceQualifierDescriptor (uint16_t *length)
 {
   *length = sizeof (USBD_CDC_DeviceQualifierDesc);
   return USBD_CDC_DeviceQualifierDesc;
+}
+
+#if defined ( __ICCARM__ ) /*!< IAR Compiler */
+  #pragma data_alignment=4   
+#endif
+__ALIGN_BEGIN uint8_t USBD_StrDesc[USBD_MAX_STR_DESC_SIZ] __ALIGN_END;
+
+
+uint8_t *USBD_CDC_GetUsrStrDescriptor(struct _USBD_HandleTypeDef *pdev, uint8_t index, uint16_t *length)
+{
+  switch (index) {
+    case 0x11: USBD_GetString((uint8_t*)"STM32 Serial1", USBD_StrDesc, length); break;
+    case 0x21: USBD_GetString((uint8_t*)"STM32 Serial2", USBD_StrDesc, length); break;
+    case 0x31: USBD_GetString((uint8_t*)"STM32 Serial3", USBD_StrDesc, length); break;
+  }
+  return USBD_StrDesc;
 }
 
 /**

--- a/culfw/STM32/hal_usart.c
+++ b/culfw/STM32/hal_usart.c
@@ -256,9 +256,11 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *UartHandle)
   if(UartHandle->Instance==USART1) {
 #ifdef HAS_UART
     UART_Rx_Callback(inbyte1);
-#else
+#elif CDC_COUNT < 4
     DBGU_RxByte = inbyte1;
     DBGU_RxReady = 1;
+#else
+	  UART1_Rx_Callback(inbyte1);
 #endif
     ATOMIC_BLOCK() {
       HAL_UART_Receive_IT(&huart1, &inbyte1, 1);
@@ -288,6 +290,11 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *UartHandle)
   if(UartHandle->Instance==USART1) {
 #ifdef HAS_UART
     UART_Tx_Callback();
+#else    
+    CDC_Receive_next(CDC3);
+#ifdef HAS_WIZNET
+    NET_Receive_next(NET3);
+#endif
 #endif
   } else if(UartHandle->Instance==USART2) {
     CDC_Receive_next(CDC1);
@@ -317,6 +324,7 @@ void HAL_UART_Set_Baudrate(uint8_t UART_num, uint32_t baudrate) {
   case 1:
     UartHandle = &huart3;
     break;
+  case 2:
   case UART_NUM:
     UartHandle = &huart1;
     break;
@@ -335,6 +343,8 @@ uint32_t HAL_UART_Get_Baudrate(uint8_t UART_num) {
     return huart2.Init.BaudRate;
   case 1:
     return huart3.Init.BaudRate;
+  case 2:
+    return huart1.Init.BaudRate;
   }
   return 0;
 }
@@ -348,6 +358,7 @@ void HAL_UART_Write(uint8_t UART_num, uint8_t* Buf, uint16_t Len) {
     case 1:
       HAL_UART_Transmit_IT(&huart3, Buf, Len);
       break;
+    case 2:
     case UART_NUM:
       HAL_UART_Transmit_IT(&huart1, Buf, Len);
       break;
@@ -364,6 +375,7 @@ void HAL_UART_init(uint8_t UART_num) {
   case 1:
     MX_USART3_UART_Init();
     break;
+  case 2:
   case UART_NUM:
     MX_USART1_UART_Init();
     break;
@@ -382,6 +394,7 @@ uint8_t HAL_UART_TX_is_idle(uint8_t UART_num) {
   case 1:
     UartHandle = &huart3;
     break;
+  case 2:
   case UART_NUM:
     UartHandle = &huart1;
     break;

--- a/culfw/STM32/usbd/usb_device.h
+++ b/culfw/STM32/usbd/usb_device.h
@@ -54,6 +54,7 @@ unsigned char USBD_GetState(void);
 #define CDC0  0
 #define CDC1  1
 #define CDC2  2
+#define CDC3  3
 
 #ifdef __cplusplus
 }

--- a/culfw/STM32/usbd/usbd_cdc_if.c
+++ b/culfw/STM32/usbd/usbd_cdc_if.c
@@ -230,6 +230,10 @@ static int8_t CDC_Control_FS  (uint8_t cmd, uint8_t* pbuf, uint16_t length, uint
         HAL_UART_Set_Baudrate(0,line_coding->dwDTERate);
       } else if(cdc_num == CDC2) {
         HAL_UART_Set_Baudrate(1,line_coding->dwDTERate);
+#if CDC_COUNT > 3
+      } else if(cdc_num == CDC3) {
+        HAL_UART_Set_Baudrate(2,line_coding->dwDTERate);
+#endif
       }
     }
 
@@ -290,6 +294,19 @@ __weak uint8_t CDCDSerialDriver_Receive_Callback2(uint8_t* Buf, uint32_t *Len)
    */
   return 1;
 }
+
+/**
+  * @brief  CDCDSerialDriver_Receive callback.
+  * @retval None
+  */
+__weak uint8_t CDCDSerialDriver_Receive_Callback3(uint8_t* Buf, uint32_t *Len)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the CDCDSerialDriver_Receive_Callback could be implemented in the user file
+   */
+  return 1;
+}
+
 /**
   * @brief  CDC_Receive_FS
   *         Data received over USB OUT endpoint are sent over CDC interface 
@@ -317,6 +334,9 @@ static int8_t CDC_Receive_FS (uint8_t* Buf, uint32_t *Len, uint8_t cdc_num)
       break;
     case 2:
       restart = CDCDSerialDriver_Receive_Callback2(Buf, Len);
+      break;
+    case 3:
+      restart = CDCDSerialDriver_Receive_Callback3(Buf, Len);
       break;
   }
 

--- a/culfw/STM32/usbd/usbd_conf.h
+++ b/culfw/STM32/usbd/usbd_conf.h
@@ -64,7 +64,7 @@
 /*---------- -----------*/
 #define USBD_MAX_STR_DESC_SIZ     512
 /*---------- -----------*/
-#define USBD_SUPPORT_USER_STRING     0
+#define USBD_SUPPORT_USER_STRING     1
 /*---------- -----------*/
 #define USBD_DEBUG_LEVEL     0
 /*---------- -----------*/

--- a/culfw/STM32/utility/dbgu.c
+++ b/culfw/STM32/utility/dbgu.c
@@ -30,7 +30,7 @@ void SWO_PrintChar(char c, uint8_t portNo) {
 }
 
 int fputc(int ch, FILE *f) {
-#ifndef HAS_UART
+#if !defined(HAS_UART) && CDC_COUNT < 4
   HAL_UART_Transmit(&huart1, (uint8_t *)&ch, 1, 0xFFFF);
 #endif
   SWO_PrintChar((uint8_t)ch,0);

--- a/culfw/Wiznet/Internet/DHCP/dhcp.c
+++ b/culfw/Wiznet/Internet/DHCP/dhcp.c
@@ -379,10 +379,7 @@ void send_DHCP_DISCOVER(void)
 	pDHCPMSG->OPT[k++] = 0;          // fill zero length of hostname 
 	for(i = 0 ; HOST_NAME[i] != 0; i++)
    	pDHCPMSG->OPT[k++] = HOST_NAME[i];
-	pDHCPMSG->OPT[k++] = DHCP_CHADDR[3];
-	pDHCPMSG->OPT[k++] = DHCP_CHADDR[4];
-	pDHCPMSG->OPT[k++] = DHCP_CHADDR[5];
-	pDHCPMSG->OPT[k - (i+3+1)] = i+3; // length of hostname
+	pDHCPMSG->OPT[k - (i+1)] = i;    // length of hostname
 
 	pDHCPMSG->OPT[k++] = dhcpParamRequest;
 	pDHCPMSG->OPT[k++] = 0x06;	// length of request
@@ -478,10 +475,7 @@ void send_DHCP_REQUEST(void)
 	pDHCPMSG->OPT[k++] = 0; // length of hostname
 	for(i = 0 ; HOST_NAME[i] != 0; i++)
    	pDHCPMSG->OPT[k++] = HOST_NAME[i];
-	pDHCPMSG->OPT[k++] = DHCP_CHADDR[3];
-	pDHCPMSG->OPT[k++] = DHCP_CHADDR[4];
-	pDHCPMSG->OPT[k++] = DHCP_CHADDR[5];
-	pDHCPMSG->OPT[k - (i+3+1)] = i+3; // length of hostname
+	pDHCPMSG->OPT[k - (i+1)] = i; // length of hostname
 	
 	pDHCPMSG->OPT[k++] = dhcpParamRequest;
 	pDHCPMSG->OPT[k++] = 0x08;

--- a/culfw/Wiznet/Internet/DHCP/dhcp.h
+++ b/culfw/Wiznet/Internet/DHCP/dhcp.h
@@ -46,6 +46,7 @@
 #define _DHCP_H_
 
 #include <stdint.h>
+#include <board.h>
 
 /*
  * @brief 
@@ -67,7 +68,9 @@
 
 #define MAGIC_COOKIE             0x63825363  ///< Any number. You can be modifyed it any number
 
+#ifndef DCHP_HOST_NAME
 #define DCHP_HOST_NAME           "WIZnet\0"
+#endif
 
 /* 
  * @brief return value of @ref DHCP_run()

--- a/culfw/clib/ethernet.h
+++ b/culfw/clib/ethernet.h
@@ -24,6 +24,7 @@ uint8_t check_Net_MAC();
 
 #define NET1  0
 #define NET2  1
+#define NET3  2
 #endif
 
 // NOTE:

--- a/culfw/clib/ethernet_wiznet.c
+++ b/culfw/clib/ethernet_wiznet.c
@@ -19,11 +19,17 @@
 #include "stringfunc.h"
 #include "ttydata.h"
 
+#define NET_COUNT     CDC_COUNT-1
+
 //////////////////////////////////////////////////
 // Socket & Port number definition for Examples //
 //////////////////////////////////////////////////
 
+#if NET_COUNT < 3
 #define SOCK_DHCP 3
+#else 
+#define SOCK_DHCP 4
+#endif
 
 ////////////////////////////////////////////////
 // Shared Buffer Definition for Loopback test //
@@ -248,7 +254,6 @@ int32_t rxtx_0() {
 }
 
 #define NET_BUF_SIZE  64
-#define NET_COUNT     CDC_COUNT-1
 
 uint8_t net_rx_buffer[NET_COUNT][NET_BUF_SIZE];
 volatile uint8_t net_rx_size[NET_COUNT];
@@ -379,6 +384,9 @@ void Ethernet_Task(void) {
 #if NET_COUNT > 1
   tcp_server( 2, 2325 );
 #endif
+#if NET_COUNT > 2
+  tcp_server( 3, 2326 );
+#endif  
 }
 
 void NET_Receive_next(uint8_t net_num) {

--- a/culfw/clib/fncollection.c
+++ b/culfw/clib/fncollection.c
@@ -298,6 +298,9 @@ eeprom_factory_reset(char *in)
 #ifdef HAS_WIZNET
   EE_write_baud(0,CDC_BAUD_RATE);
   EE_write_baud(1,CDC_BAUD_RATE);
+#if CDC_COUNT > 3
+  EE_write_baud(2,CDC_BAUD_RATE);
+#endif  
 #endif
 
   if(in[1] != 'x')

--- a/culfw/clib/fncollection.h
+++ b/culfw/clib/fncollection.h
@@ -54,7 +54,12 @@ void do_wdt_enable(uint8_t t);
 #if defined(CDC_COUNT) && (CDC_COUNT > 1)
 # define EE_CDC1_BAUD        (EE_IP4_NTPOFFSET+1)
 # define EE_CDC2_BAUD        (EE_CDC1_BAUD+4)
+#if (CDC_COUNT > 3)
+# define EE_CDC3_BAUD        (EE_CDC2_BAUD+4)
+# define EE_ETH_LAST         (EE_CDC3_BAUD+4)
+#else
 # define EE_ETH_LAST         (EE_CDC2_BAUD+4)
+#endif // CDC_COUNT > 3
 #else
 # define EE_ETH_LAST         (EE_IP4_NTPOFFSET+1)       // 
 #endif


### PR DESCRIPTION
Added possibility to expose first UART of STm32 to usb / network (instead of using it for an attached ESP8266 or as a logging interface)