### PR TITLE
add devcontainer and some vsode settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+ARG ARM_TOOLCHAIN_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/5_4-2016q3/gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2?rev=111dee36f88b46728ac648cf41b4d375&revision=111dee36-f88b-4672-8ac6-48cf41b4d375?product=GNU%20Arm%20Embedded%20Toolchain%20Downloads,32-bit,,Linux,5-2016-q3-update
+
+RUN dpkg --add-architecture i386 && \
+    apt update && \
+    apt dist-upgrade -y && \
+    apt install -y libc6:i386 libstdc++6:i386
+    #rm -rf /var/lib/apt/lists/*
+
+RUN wget $ARM_TOOLCHAIN_URL -O gcc-arm-none-eabi.tar.bz2 && \
+    tar -xjf gcc-arm-none-eabi.tar.bz2 && \
+    rm gcc-arm-none-eabi.tar.bz2 && \
+    mv gcc-arm-none-eabi-5_4-2016q3 /opt/gcc-arm-none-eabi-5_4-2016q3
+
+ENV PATH="/opt/gcc-arm-none-eabi-5_4-2016q3/bin:${PATH}"
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"dockerFile": "Dockerfile"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools-extension-pack",
+        "ms-vscode.makefile-tools"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "makefile.makefilePath": "culfw/Devices/MapleCUN/makefile",
+    "makefile.makeDirectory": "culfw/Devices/MapleCUN"
+}


### PR DESCRIPTION
This adds a devcontainer to the project that provides a development and build environment that also downloads and adds the correct ARM toolchain to PATH.